### PR TITLE
fix(domains): use @repo/typescript-config for tsconfig consistency

### DIFF
--- a/packages/domains/package.json
+++ b/packages/domains/package.json
@@ -14,6 +14,7 @@
     }
   },
   "devDependencies": {
+    "@repo/typescript-config": "workspace:*",
     "zod": "^4"
   },
   "peerDependencies": {

--- a/packages/domains/tsconfig.json
+++ b/packages/domains/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../packages/typescript-config/base.json",
+  "extends": "@repo/typescript-config/base.json",
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -208,6 +208,9 @@ importers:
 
   packages/domains:
     devDependencies:
+      '@repo/typescript-config':
+        specifier: workspace:*
+        version: link:../typescript-config
       zod:
         specifier: ^4
         version: 4.3.6


### PR DESCRIPTION
- Replace relative path with @repo/typescript-config/base.json to match other packages (i18n, ui) per Turborepo best practices
- Add @repo/typescript-config as devDependency